### PR TITLE
feat: change signer identity subjects to a version pattern

### DIFF
--- a/policy/governance/identities.rego
+++ b/policy/governance/identities.rego
@@ -3,10 +3,10 @@ package governance
 signer_identities := [
     {
         "issuer": "https://token.actions.githubusercontent.com",
-        "subject": "https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/build-and-push.yaml@refs/heads/main",
+        "subjectRegExp": `^https://github\.com/liatrio/gh-trusted-builds-workflows/\.github/workflows/build-and-push\.yaml@refs/tags/v\d\.\d\.\d$`,
     },
     {
        "issuer": "https://token.actions.githubusercontent.com",
-       "subject": "https://github.com/liatrio/gh-trusted-builds-workflows/.github/workflows/scan-image.yaml@refs/heads/main",
+       "subjectRegExp": `^https://github\.com/liatrio/gh-trusted-builds-workflows/\.github/workflows/scan-image\.yaml@refs/tags/v\d\.\d\.\d$`,
     }
 ]


### PR DESCRIPTION
I tested this locally with an image built from using the workflow tags. 

https://search.sigstore.dev/?logIndex=22779551