### PR TITLE
fix: signer identity subject regex

### DIFF
--- a/policy/governance/identities.rego
+++ b/policy/governance/identities.rego
@@ -3,10 +3,10 @@ package governance
 signer_identities := [
     {
         "issuer": "https://token.actions.githubusercontent.com",
-        "subjectRegExp": `^https://github\.com/liatrio/gh-trusted-builds-workflows/\.github/workflows/build-and-push\.yaml@refs/tags/v\d\.\d\.\d$`,
+        "subjectRegExp": `^https://github\.com/liatrio/gh-trusted-builds-workflows/\.github/workflows/build-and-push\.yaml@refs/tags/v\d+\.\d+\.\d+$`,
     },
     {
        "issuer": "https://token.actions.githubusercontent.com",
-       "subjectRegExp": `^https://github\.com/liatrio/gh-trusted-builds-workflows/\.github/workflows/scan-image\.yaml@refs/tags/v\d\.\d\.\d$`,
+       "subjectRegExp": `^https://github\.com/liatrio/gh-trusted-builds-workflows/\.github/workflows/scan-image\.yaml@refs/tags/v\d+\.\d+\.\d+$`,
     }
 ]


### PR DESCRIPTION
Patch versions > 9 were failing to match 🤦 
